### PR TITLE
chore(set-up): set pre-commit and prepare-commit-msg hooks

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,81 @@
+#!/bin/bash
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+NC="\033[0m"
+
+function remove_last_char_if_not_empty() {
+  container=("$@")
+  if [[ -n "$container" ]]; then
+    container=${container::-1}
+  fi
+  echo "$container"
+}
+
+function create_pattern() {
+  files_paths_list=("$@")
+  pattern=""
+  for file_name in $files_paths_list; do
+    pattern="${pattern}${file_name}|"
+  done
+  pattern=$(remove_last_char_if_not_empty "${pattern[*]}")
+  echo "$pattern"
+}
+
+function filter_array_with_inverted_regEx() {
+  files_paths_list=("$@")
+  query=$2
+  container=""
+  if [[ -z "${query}" ]]; then
+    container=$files_paths_list
+  else
+    for value in $files_paths_list; do
+      matched_string=$(echo "$value" | grep -v -E "$query")
+      if [[ -n "$matched_string" ]]; then
+        container="${container}${value} "
+      fi
+    done
+    container=$(remove_last_char_if_not_empty "${container[*]}")
+  fi
+  echo "$container"
+}
+
+function add_files_to_staged_tree() {
+  files_paths=("$@")
+  if [[ -n "${files_paths// /}" ]]; then
+    git add $files_paths
+  fi
+}
+
+eslint_autofix_flag=""
+eslint_exit_code=0
+mocha_exit_code=0
+not_staged_ts_files=$(git diff --diff-filter=b --name-only | grep .ts$)
+staged_ts_files=$(git diff --cached --diff-filter=d --name-only | grep .ts$)
+ts_filter_regex=$(create_pattern "${not_staged_ts_files[*]}")
+ts_files_to_add_after_linting=$(filter_array_with_inverted_regEx "${staged_ts_files[*]}" "${ts_filter_regex}")
+
+if [ ${#ts_files_to_add_after_linting} = ${#staged_ts_files} ]; then
+  eslint_autofix_flag="--fix"
+fi
+if [[ -n "$staged_ts_files" ]]; then
+  echo "Running ESLint..."
+  ./node_modules/.bin/eslint $staged_ts_files --quiet $eslint_autofix_flag
+  eslint_exit_code=$?
+  if [ $eslint_exit_code = 0 ]; then
+    echo -e "${GREEN} ✔ Eslint checks passed ${NC}"
+  fi
+  echo "Running Tests..."
+  ./node_modules/.bin/mocha -r @swc/register --reporter dot
+  mocha_exit_code=$?
+  if [ $mocha_exit_code = 0 ]; then
+    echo -e "${GREEN} ✔ All tests passed' ${NC}"
+  fi
+fi
+if [ $eslint_exit_code = 0 ] && [ $mocha_exit_code = 0 ]; then
+  add_files_to_staged_tree "${ts_files_to_add_after_linting[*]}"
+  echo -e "${GREEN} ✔ Committed successfully *^____^* ${NC}"
+  exit 0
+else
+  echo -e "${RED} ❌ Couldn't commit changes dues to above errors ＞﹏＜ ${NC}"
+  exit 1
+fi

--- a/git-hooks/prepare-commit-msg
+++ b/git-hooks/prepare-commit-msg
@@ -1,0 +1,8 @@
+#!/bin/bash
+COMMIT_MSG_FILE=$1
+issue_id=$(git symbolic-ref --short HEAD | grep -o '^[[:digit:]]*')
+cat $COMMIT_MSG_FILE | grep -q GH-$issue_id
+if [ $? = 1 ] && [[ -n "${issue_id// /}" ]]; then
+  echo >>$COMMIT_MSG_FILE
+  echo "Related work item: GH-$issue_id" >>$COMMIT_MSG_FILE
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "web-hand",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "git+https://github.com/web-hand/web-hand.git"
   },
   "scripts": {
+    "postinstall": "git config core.hooksPath ./git-hooks",
     "start": "webpack --watch --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "lint": "eslint . --ext .ts",


### PR DESCRIPTION
In this PR I set up **pre-commit** and **prepare-commit-msg** hooks to run every time before commit.

 - **pre-commit** → will run eslint prettier and tests every time before committing changes
 - **prepare-commit-msg** → will attach GH issue number to commit message, so you do not need to remember about this. There is only one condition, you need to add GH issue number before your local branch name. For example: `3-set-up-git-hooks` where **3** is my ticket number