### PR TITLE
feat(point3d): add point3d with appropriate tests

### DIFF
--- a/src/structures/Point3D/Point3D.ts
+++ b/src/structures/Point3D/Point3D.ts
@@ -1,0 +1,22 @@
+import { IPoint3D } from './Point3D.types';
+
+const SQUARE_POWER = 2;
+
+export class Point3D implements IPoint3D {
+  x: number;
+  y: number;
+  z: number;
+
+  constructor(x: number, y: number, z: number) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  distanceTo(point: IPoint3D): number {
+    const xPart = Math.pow(point.x - this.x, SQUARE_POWER);
+    const yPart = Math.pow(point.y - this.y, SQUARE_POWER);
+    const zPart = Math.pow(point.z - this.z, SQUARE_POWER);
+    return Math.sqrt(xPart + yPart + zPart);
+  }
+}

--- a/src/structures/Point3D/Point3D.types.ts
+++ b/src/structures/Point3D/Point3D.types.ts
@@ -1,0 +1,9 @@
+export interface Coordinates3D {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface IPoint3D extends Coordinates3D {
+  distanceTo(point: IPoint3D): number;
+}

--- a/test/mochaSetup.ts
+++ b/test/mochaSetup.ts
@@ -1,11 +1,13 @@
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import { createGlobalStubs } from './stubs/createGlobalStubs';
 import { NAVIGATOR } from './mocks/NAVIGATOR.mock';
 import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 
+createGlobalStubs();
 Object.defineProperty(window, 'navigator', {
   get: () => {
     return NAVIGATOR;

--- a/test/stubs/HTML_MEDIA_ELEMENT.stub.ts
+++ b/test/stubs/HTML_MEDIA_ELEMENT.stub.ts
@@ -1,0 +1,4 @@
+import * as sinon from 'sinon';
+
+export const HTML_MEDIA_ELEMENT_PLAY_STUB = sinon.stub(HTMLMediaElement.prototype, 'play').returns(Promise.resolve());
+export const HTML_MEDIA_ELEMENT_PAUSE_STUB = sinon.stub(HTMLMediaElement.prototype, 'pause').returns();

--- a/test/stubs/createGlobalStubs.ts
+++ b/test/stubs/createGlobalStubs.ts
@@ -1,0 +1,7 @@
+import { HTML_MEDIA_ELEMENT_PAUSE_STUB, HTML_MEDIA_ELEMENT_PLAY_STUB } from './HTML_MEDIA_ELEMENT.stub';
+
+export function createGlobalStubs(): void {
+  console.info(
+    `${HTMLMediaElement.name} stub has been created. Stubbed methods: [${HTML_MEDIA_ELEMENT_PLAY_STUB.name}, ${HTML_MEDIA_ELEMENT_PAUSE_STUB.name}]`
+  );
+}

--- a/test/unit/structures/Point3D.spec.ts
+++ b/test/unit/structures/Point3D.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { Point3D } from '../../../src/structures/Point3D/Point3D';
+
+describe(Point3D.name, () => {
+  describe(Point3D.prototype.distanceTo.name, () => {
+    it('should return the correct distance for two points with different coordinates', () => {
+      const point1 = new Point3D(1, 2, 3);
+      const point2 = new Point3D(4, 5, 6);
+      expect(point1.distanceTo(point2)).to.be.closeTo(5.196152422706632, 0.0001);
+    });
+
+    it('should return 0 for two points with same coordinates', () => {
+      const point1 = new Point3D(1, 2, 3);
+      const point2 = new Point3D(1, 2, 3);
+      expect(point1.distanceTo(point2)).to.equal(0);
+    });
+
+    it('should return the correct distance for two points with negative coordinates', () => {
+      const point1 = new Point3D(-1, -2, -3);
+      const point2 = new Point3D(-4, -5, -6);
+      expect(point1.distanceTo(point2)).to.be.closeTo(5.19615242270663, 0.0001);
+    });
+  });
+});


### PR DESCRIPTION
In this PR I have created a simple helper class `Point3D` that will help us in points operations 

Related work item: GH-37
Closes: #37 